### PR TITLE
Add interest level filtering to job columns

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Prospect } from "@shared/schema";
-import { STATUSES } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import { ProspectCard } from "@/components/prospect-card";
 import { AddProspectForm } from "@/components/add-prospect-form";
 import { Briefcase, Plus } from "lucide-react";
@@ -15,6 +15,13 @@ import {
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 const columnColors: Record<string, string> = {
   Bookmarked: "bg-blue-500",
@@ -26,15 +33,26 @@ const columnColors: Record<string, string> = {
   Withdrawn: "bg-gray-500",
 };
 
+const INTEREST_FILTER_OPTIONS = ["All", ...INTEREST_LEVELS] as const;
+
 function KanbanColumn({
   status,
   prospects,
   isLoading,
+  interestFilter,
+  onInterestFilterChange,
 }: {
   status: string;
   prospects: Prospect[];
   isLoading: boolean;
+  interestFilter: string;
+  onInterestFilterChange: (value: string) => void;
 }) {
+  const filteredProspects =
+    interestFilter === "All"
+      ? prospects
+      : prospects.filter((p) => p.interestLevel === interestFilter);
+
   return (
     <div
       className="flex flex-col min-w-[260px] max-w-[320px] w-full bg-muted/40 rounded-md"
@@ -48,8 +66,32 @@ function KanbanColumn({
           className="ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
           data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
         >
-          {prospects.length}
+          {filteredProspects.length}
         </Badge>
+      </div>
+      <div className="px-2 pt-2">
+        <Select
+          value={interestFilter}
+          onValueChange={onInterestFilterChange}
+        >
+          <SelectTrigger
+            className="h-7 text-xs w-full"
+            data-testid={`filter-interest-${status.replace(/\s+/g, "-").toLowerCase()}`}
+          >
+            <SelectValue placeholder="Interest" />
+          </SelectTrigger>
+          <SelectContent>
+            {INTEREST_FILTER_OPTIONS.map((level) => (
+              <SelectItem
+                key={level}
+                value={level}
+                data-testid={`filter-option-${level.toLowerCase()}-${status.replace(/\s+/g, "-").toLowerCase()}`}
+              >
+                {level === "All" ? "All Interest Levels" : level}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <div className="space-y-2">
@@ -58,12 +100,12 @@ function KanbanColumn({
               <Skeleton className="h-28 rounded-md" />
               <Skeleton className="h-20 rounded-md" />
             </>
-          ) : prospects.length === 0 ? (
+          ) : filteredProspects.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${status.replace(/\s+/g, "-").toLowerCase()}`}>
               <p className="text-xs text-muted-foreground">No prospects</p>
             </div>
           ) : (
-            prospects.map((prospect) => (
+            filteredProspects.map((prospect) => (
               <ProspectCard key={prospect.id} prospect={prospect} />
             ))
           )}
@@ -75,6 +117,9 @@ function KanbanColumn({
 
 export default function Home() {
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [interestFilters, setInterestFilters] = useState<Record<string, string>>(
+    () => Object.fromEntries(STATUSES.map((s) => [s, "All"])),
+  );
 
   const { data: prospects, isLoading } = useQuery<Prospect[]>({
     queryKey: ["/api/prospects"],
@@ -134,6 +179,10 @@ export default function Home() {
               status={status}
               prospects={groupedByStatus[status] || []}
               isLoading={isLoading}
+              interestFilter={interestFilters[status]}
+              onInterestFilterChange={(value) =>
+                setInterestFilters((prev) => ({ ...prev, [status]: value }))
+              }
             />
           ))}
         </div>

--- a/replit.md
+++ b/replit.md
@@ -17,7 +17,8 @@ server/
   db.ts                       - PostgreSQL connection pool (Drizzle)
   routes.ts                   - API route handlers (GET/POST/PATCH/DELETE)
   storage.ts                  - Storage interface + DatabaseStorage class
-  prospect-helpers.ts         - Pure helper functions (getNextStatus, validateProspect, isTerminalStatus)
+  prospect-helpers.ts         - Pure helper functions (getNextStatus, validateProspect, isTerminalStatus, filterProspectsByInterest)
+  prospect-helpers.test.ts    - Jest tests for prospect helper functions
 client/src/
   App.tsx                     - Root component, routing, providers
   pages/home.tsx              - Kanban board with 7 status columns
@@ -46,3 +47,8 @@ Single `prospects` table: id, company_name, role_title, job_url, status, interes
 
 - `npm run dev` starts the full app (Express + Vite)
 - `npm run db:push` syncs schema to database
+- `npm test` runs Jest tests (including interest level filter tests)
+
+## Features
+
+- **Per-column interest level filter**: Each Kanban column has a dropdown to filter prospects by interest level (All/High/Medium/Low). Filters are independent per column and operate client-side only (no server calls). Badge counts reflect the filtered view.

--- a/server/prospect-helpers.test.ts
+++ b/server/prospect-helpers.test.ts
@@ -1,0 +1,74 @@
+import { filterProspectsByInterest, getNextStatus, validateProspect, isTerminalStatus } from "./prospect-helpers";
+
+describe("filterProspectsByInterest", () => {
+  const prospects = [
+    { id: 1, companyName: "Acme", interestLevel: "High", status: "Bookmarked" },
+    { id: 2, companyName: "Beta", interestLevel: "Medium", status: "Bookmarked" },
+    { id: 3, companyName: "Gamma", interestLevel: "Low", status: "Bookmarked" },
+    { id: 4, companyName: "Delta", interestLevel: "High", status: "Applied" },
+    { id: 5, companyName: "Echo", interestLevel: "Medium", status: "Applied" },
+  ];
+
+  it("returns all prospects when filter is 'All'", () => {
+    const result = filterProspectsByInterest(prospects, "All");
+    expect(result).toHaveLength(5);
+    expect(result).toEqual(prospects);
+  });
+
+  it("returns all prospects when filter is empty string", () => {
+    const result = filterProspectsByInterest(prospects, "");
+    expect(result).toHaveLength(5);
+  });
+
+  it("filters by 'High' interest level", () => {
+    const result = filterProspectsByInterest(prospects, "High");
+    expect(result).toHaveLength(2);
+    expect(result.every((p) => p.interestLevel === "High")).toBe(true);
+    expect(result.map((p) => p.companyName)).toEqual(["Acme", "Delta"]);
+  });
+
+  it("filters by 'Medium' interest level", () => {
+    const result = filterProspectsByInterest(prospects, "Medium");
+    expect(result).toHaveLength(2);
+    expect(result.every((p) => p.interestLevel === "Medium")).toBe(true);
+  });
+
+  it("filters by 'Low' interest level", () => {
+    const result = filterProspectsByInterest(prospects, "Low");
+    expect(result).toHaveLength(1);
+    expect(result[0].companyName).toBe("Gamma");
+  });
+
+  it("returns all prospects for an invalid filter value", () => {
+    const result = filterProspectsByInterest(prospects, "Invalid");
+    expect(result).toHaveLength(5);
+  });
+
+  it("returns empty array when no prospects match the filter", () => {
+    const noLow = [
+      { id: 1, companyName: "A", interestLevel: "High", status: "Bookmarked" },
+      { id: 2, companyName: "B", interestLevel: "High", status: "Applied" },
+    ];
+    const result = filterProspectsByInterest(noLow, "Low");
+    expect(result).toHaveLength(0);
+  });
+
+  it("works with an empty prospects array", () => {
+    const result = filterProspectsByInterest([], "High");
+    expect(result).toHaveLength(0);
+  });
+
+  it("supports independent per-column filtering", () => {
+    const bookmarked = prospects.filter((p) => p.status === "Bookmarked");
+    const applied = prospects.filter((p) => p.status === "Applied");
+
+    const bookmarkedHigh = filterProspectsByInterest(bookmarked, "High");
+    const appliedMedium = filterProspectsByInterest(applied, "Medium");
+
+    expect(bookmarkedHigh).toHaveLength(1);
+    expect(bookmarkedHigh[0].companyName).toBe("Acme");
+
+    expect(appliedMedium).toHaveLength(1);
+    expect(appliedMedium[0].companyName).toBe("Echo");
+  });
+});

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -45,3 +45,16 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
 export function isTerminalStatus(status: string): boolean {
   return status === "Rejected" || status === "Withdrawn" || status === "Offer";
 }
+
+export function filterProspectsByInterest<T extends { interestLevel: string }>(
+  prospects: T[],
+  filter: string,
+): T[] {
+  if (!filter || filter === "All") {
+    return prospects;
+  }
+  if (!INTEREST_LEVELS.includes(filter as (typeof INTEREST_LEVELS)[number])) {
+    return prospects;
+  }
+  return prospects.filter((p) => p.interestLevel === filter);
+}


### PR DESCRIPTION
Implement client-side filtering by interest level for job prospects within each Kanban column, including adding helper functions and corresponding unit tests.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 7f2ffef3-692f-4173-8aa9-a363130d703e
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 2193ca57-cdf8-4b42-9ef4-06bc54f2a2d3
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/93cb8fa1-b3d1-41f2-8972-8346c9995fe5/7f2ffef3-692f-4173-8aa9-a363130d703e/DG4FbUb
Replit-Helium-Checkpoint-Created: true